### PR TITLE
update to radbeacon-flasher v0.2.0

### DIFF
--- a/Formula/radbeacon-flasher.rb
+++ b/Formula/radbeacon-flasher.rb
@@ -3,12 +3,12 @@ require "formula"
 class RadbeaconFlasher < Formula
   homepage "https://github.com/RadiusNetworks/radbeacon-flasher"
   head "git@github.com:RadiusNetworks/radbeacon-flasher.git"
-  url "https://github.com/RadiusNetworks/radbeacon-flasher/archive/v0.1.0.tar.gz"
+  url "https://github.com/RadiusNetworks/radbeacon-flasher/archive/v0.2.0.tar.gz"
 
   # To create the sha256:
   # curl -L "https://github.com/PATH" | shasum -a 256
-  sha256 "f6eba1625aad142781572cf0ccd8361b962c0320550e1616082dd9e8972f15c4"
-  version "0.1.0"
+  sha256 "4183646ed24f537d4032b17ff84f51c255d8435679eec7fcd12d3354aaa9553a"
+  version "0.2.0"
 
   depends_on "dfu-util"
   depends_on "serhex"


### PR DESCRIPTION
radbeacon-flasher uses the v3.2.3 firmware as the default (old default was v2.2.0)
