### PR TITLE
Add Formula for proj version 6.3.1

### DIFF
--- a/Formula/proj.rb
+++ b/Formula/proj.rb
@@ -1,0 +1,54 @@
+require 'formula'
+
+class Proj < Formula
+  desc 'Cartographic Projections Library'
+  homepage 'https://proj4.org/'
+  url 'https://download.osgeo.org/proj/proj-6.3.1.tar.gz'
+  sha256 '6de0112778438dcae30fcc6942dee472ce31399b9e5a2b67e8642529868c86f8'
+
+  head do
+    url 'https://github.com/OSGeo/proj.4.git'
+    depends_on 'autoconf' => :build
+    depends_on 'automake' => :build
+    depends_on 'libtool' => :build
+  end
+
+  depends_on 'pkg-config' => :build
+
+  conflicts_with 'blast', because: 'both install a `libproj.a` library'
+
+  skip_clean :la
+
+  # The datum grid files are required to support datum shifting
+  resource 'datumgrid' do
+    url 'https://download.osgeo.org/proj/proj-datumgrid-1.8.zip'
+    sha256 'b9838ae7e5f27ee732fb0bfed618f85b36e8bb56d7afb287d506338e9f33861e'
+  end
+
+  def install
+    (buildpath / 'nad').install resource('datumgrid')
+
+    system './autogen.sh' if build.head?
+    system './configure', '--disable-dependency-tracking',
+           "--prefix=#{prefix}"
+    system 'make', 'install'
+  end
+
+  test do
+    (testpath / 'test').write <<~EOS
+      45d15n 71d07w Boston, United States
+      40d40n 73d58w New York, United States
+      48d51n 2d20e Paris, France
+      51d30n 7'w London, England
+    EOS
+    match = <<~EOS
+      -4887590.49\t7317961.48 Boston, United States
+      -5542524.55\t6982689.05 New York, United States
+      171224.94\t5415352.81 Paris, France
+      -8101.66\t5707500.23 London, England
+    EOS
+
+    output = shell_output("#{bin}/proj +proj=poly +ellps=clrk66 -r #{testpath}/test")
+    assert_equal match, output
+  end
+end


### PR DESCRIPTION
Heroku-20 stack only has proj4 version 6.3.1 available and we want
to be running the same version on our development environment as we
use in production. Homebrew core only has formula for versions 7 and 8
of proj4 so we want to host our own formula for proj version 6.3.1 to
ease the process of setting up our development environment. (no
building from source)

This Formula is based almost entirely off of [the one we currently use](https://github.com/sethdeckard/homebrew-proj/blob/master/Formula/proj.rb). The changes that are worth calling out here are...

1. The `.tar.gz` file this is pointing to was changed to the correct download from [this](https://proj.org/download.html#) page.
2. The sha256 checksum has been updated to the sha256 checksum for the file mentioned ☝️ Above.

I have tested this Forumula locally by running...

```sh
$ brew install --build-from-source ./Formula/proj.rb
```

Then I checked out the branch from [this](https://github.com/RadiusNetworks/iris/pull/4088) PR, opened a rails console and ran...

```
[1] pry(main)> RGeo::CoordSys::Proj4.version
=> "6.3.1"
[2] pry(main)> RGeo::CoordSys::Proj4.supported?
=> true
```
  