### PR TITLE
Add pg_partman formula for PostgreSQL 16

### DIFF
--- a/Formula/pg_partman.rb
+++ b/Formula/pg_partman.rb
@@ -1,0 +1,72 @@
+class PgPartman < Formula
+  desc "Partition management extension for PostgreSQL"
+  homepage "https://github.com/pgpartman/pg_partman"
+  url "https://github.com/pgpartman/pg_partman/archive/refs/tags/v5.4.3.tar.gz"
+  sha256 "c52e3b8cf80d306468f48fbdb1905e4c2574bf8362240af57aebbbf9e18c6fe2"
+  license "PostgreSQL"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "postgresql@16" => [:build, :test]
+
+  def postgresqls
+    deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("postgresql@") }
+  end
+
+  def install
+    postgresqls.each do |postgresql|
+      ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
+
+      system "make"
+      system "make", "install", "bindir=#{bin}",
+                                "docdir=#{doc}",
+                                "datadir=#{share/postgresql.name}",
+                                "pkglibdir=#{lib/postgresql.name}"
+      system "make", "clean"
+    end
+  end
+
+  def caveats
+    cmds = postgresqls.map do |postgresql|
+      pg_share = postgresql.opt_share/postgresql.name/"extension"
+      pg_lib = postgresql.opt_lib/"postgresql"
+      <<~EOS
+        # #{postgresql.name}
+        ln -sf #{opt_share/postgresql.name}/extension/pg_partman* #{pg_share}/
+        ln -sf #{opt_lib/postgresql.name}/pg_partman* #{pg_lib}/
+      EOS
+    end.join("\n")
+
+    <<~EOS
+      To make pg_partman visible to PostgreSQL, symlink the extension files:
+
+      #{cmds}
+    EOS
+  end
+
+  test do
+    ENV["LC_ALL"] = "C"
+    postgresqls.each do |postgresql|
+      pg_ctl = postgresql.opt_bin/"pg_ctl"
+      psql = postgresql.opt_bin/"psql"
+      port = free_port
+
+      datadir = testpath/postgresql.name
+      system pg_ctl, "initdb", "-D", datadir
+      (datadir/"postgresql.conf").write <<~EOS, mode: "a+"
+
+        shared_preload_libraries = 'pg_partman_bgw'
+        port = #{port}
+      EOS
+      system pg_ctl, "start", "-D", datadir, "-l", testpath/"log-#{postgresql.name}"
+      begin
+        system psql, "-p", port.to_s, "-c", "CREATE EXTENSION \"pg_partman\";", "postgres"
+      ensure
+        system pg_ctl, "stop", "-D", datadir
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `pg_partman` formula (v5.4.3) to the tap, adapted from the homebrew-core version with `postgresql@16` as the sole dependency. The bottle block is removed so it builds from source, since the upstream prebuilt bottles don't match our modified dependency set.

Includes a `caveats` block with symlink commands that the user must run after install. This is necessary because Homebrew's sandbox prevents writing extension files directly into PostgreSQL's Cellar, and PostgreSQL only looks for extensions in its own `pg_config --sharedir` path rather than the Homebrew-linked prefix.

## Test plan

- [x] `brew tap RadiusNetworks/utils`
- [x] `brew install RadiusNetworks/utils/pg_partman` succeeds
- [x] Running the symlink commands from caveats puts the extension files where PostgreSQL looks
- [x] `SELECT * FROM pg_available_extensions WHERE name = 'pg_partman';` returns the extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)